### PR TITLE
Fix so that asciidoc files with no stem content will successfully complete.

### DIFF
--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -98,7 +98,7 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
 
           ::IO.write img_file, eq_result[:data]
           %(image:#{img_target}[width=#{eq_result[:width]},height=#{eq_result[:height]}])
-        } if (source.include? ':') && ((support_stem_prefix && (source.include? 'stem:')) || (source.include? 'latexmath:'))
+        } if (source != nil) && (source.include? ':') && ((support_stem_prefix && (source.include? 'stem:')) || (source.include? 'latexmath:'))
 
         if source_modified
           if block.context == :list_item


### PR DESCRIPTION
I have looked into using this extension for a fairly large project which include a number of files that have no stem content. Such files cause an error in line 101 as it is assumed that "source" is not nil (i.e. there were 1 or more stem blocks).

This PR adds a check for nil so that such files can successfully complete.