### PR TITLE
Add option to inline equations as SVG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@ asciidoctor-mathematical processes `latexmath` and `stem` blocks and inline
 macros and replaces them with generated SVG or PNG images, thus enables `stem`
 contents on a much wider range of asciidoctor backends. Currently, it is
 tested to works well with the html, docbook, pdf and latex backends. For
-`stem` blocks and macros, only the `latexmath` type is supported. 
+`stem` blocks and macros, only the `latexmath` type is supported.
 
 ### Package Specific Attributes
 
 These attributes can be set to tweak behaviors of this package:
 
-| attribute           | description                                       | valid values        | default value |
-| ---------           | -----------                                       | -------------       | ------------- |
-| mathematical-format | format of generated images                        | svg, png            | png           |
-| mathematical-ppi    | ppi of generated images, only valid for png files | any positive number | 300.0         |
+| attribute           | description                                                           | valid values        | default value |
+| ---------           | -----------                                                           | -------------       | ------------- |
+| mathematical-format | format of generated images                                            | svg, png            | png           |
+| mathematical-ppi    | ppi of generated images, only valid for png files                     | any positive number | 300.0         |
+| mathematical-inline | if present will inline equations as svg (only useful for HTML output) | true/false          | false         |
 
 ## Usage
 `asciidoctor-pdf -r asciidoctor-mathematical -o test.pdf sample.adoc`

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -17,22 +17,28 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
     end
     ppi = ((document.attr 'mathematical-ppi') || '300.0').to_f
     ppi = format == :png ? ppi : 72.0
+    inline = document.attr 'mathematical-inline'
+    if inline and format == :png
+      warn 'Can\'t use mathematical-inline together with mathematical-format=png'
+    end
     # The no-args constructor defaults to SVG and standard delimiters ($..$ for inline, $$..$$ for block)
     mathematical = ::Mathematical.new format: format, ppi: ppi
-    image_output_dir, image_target_dir = image_output_and_target_dir document
-    ::Asciidoctor::Helpers.mkdir_p image_output_dir unless ::File.directory? image_output_dir
+    unless inline
+      image_output_dir, image_target_dir = image_output_and_target_dir document
+      ::Asciidoctor::Helpers.mkdir_p image_output_dir unless ::File.directory? image_output_dir
+    end
 
     unless (stem_blocks = document.find_by context: :stem).nil_or_empty?
       stem_blocks.each do |stem|
-        handle_stem_block stem, mathematical, image_output_dir, image_target_dir, format
+        handle_stem_block stem, mathematical, image_output_dir, image_target_dir, format, inline
       end
     end
 
     unless (prose_blocks = document.find_by {|b|
-          (b.content_model == :simple && (b.subs.include? :macros)) || b.context == :list_item
-        }).nil_or_empty?
+      (b.content_model == :simple && (b.subs.include? :macros)) || b.context == :list_item
+    }).nil_or_empty?
       prose_blocks.each do |prose|
-        handle_prose_block prose, mathematical, image_output_dir, image_target_dir, format
+        handle_prose_block prose, mathematical, image_output_dir, image_target_dir, format, inline
       end
     end
 
@@ -45,7 +51,7 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
             if cell.style == :asciidoc
               process cell.inner_document
             elsif cell.style != :literal
-              handle_nonasciidoc_table_cell cell, mathematical, image_output_dir, image_target_dir, format
+              handle_nonasciidoc_table_cell cell, mathematical, image_output_dir, image_target_dir, format, inline
             end
           end
         end
@@ -54,38 +60,44 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
 
     unless (sect_blocks = document.find_by content: :section).nil_or_empty?
       sect_blocks.each do |sect|
-        handle_section_title sect, mathematical, image_output_dir, image_target_dir, format
+        handle_section_title sect, mathematical, image_output_dir, image_target_dir, format, inline
       end
     end
 
     nil
   end
 
-  def handle_stem_block(stem, mathematical, image_output_dir, image_target_dir, format)
+  def handle_stem_block(stem, mathematical, image_output_dir, image_target_dir, format, inline)
     equation_type = stem.style.to_sym
     return unless equation_type == :latexmath
 
-    img_target, img_width, img_height = make_equ_image stem.content, stem.id, false, mathematical, image_output_dir, image_target_dir, format
+    img_target, img_width, img_height = make_equ_image stem.content, stem.id, false, mathematical, image_output_dir, image_target_dir, format, inline
 
-    alt_text = stem.attr 'alt', %($$#{stem.content}$$)
-    attrs = { 'target' => img_target, 'alt' => alt_text, 'align' => 'center' }
-    # NOTE: The following setups the *intended width and height in pixel* for png images, which can be different that that of the generated image when PPIs larger than 72.0 is used.
-    if format == :png
-      attrs['width'] = %(#{img_width})
-      attrs['height'] = %(#{img_height})
-    end
     parent = stem.parent
-    stem_image = create_image_block parent, attrs
-    stem_image.id = stem.id if stem.id
-    if (title = stem.attributes['title'])
-      stem_image.title = title
+    if inline
+      stem_image = create_pass_block parent, %{<div class="stemblock"> #{img_target} </div>}, {}
+      parent.blocks[parent.blocks.index stem] = stem_image
+    else
+      alt_text = stem.attr 'alt', %($$#{stem.content}$$)
+      attrs = {'target' => img_target, 'alt' => alt_text, 'align' => 'center'}
+      # NOTE: The following setups the *intended width and height in pixel* for png images, which can be different that that of the generated image when PPIs larger than 72.0 is used.
+      if format == :png
+        attrs['width'] = %(#{img_width})
+        attrs['height'] = %(#{img_height})
+      end
+      parent = stem.parent
+      stem_image = create_image_block parent, attrs
+      stem_image.id = stem.id if stem.id
+      if (title = stem.attributes['title'])
+        stem_image.title = title
+      end
+      parent.blocks[parent.blocks.index stem] = stem_image
     end
-    parent.blocks[parent.blocks.index stem] = stem_image
   end
 
-  def handle_prose_block(prose, mathematical, image_output_dir, image_target_dir, format)
+  def handle_prose_block(prose, mathematical, image_output_dir, image_target_dir, format, inline)
     text = prose.context == :list_item ? (prose.instance_variable_get :@text) : (prose.lines * LineFeed)
-    text, source_modified = handle_inline_stem prose, text, mathematical, image_output_dir, image_target_dir, format
+    text, source_modified = handle_inline_stem prose, text, mathematical, image_output_dir, image_target_dir, format, inline
     if source_modified
       if prose.context == :list_item
         prose.instance_variable_set :@text, text
@@ -95,24 +107,24 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
     end
   end
 
-  def handle_nonasciidoc_table_cell(cell, mathematical, image_output_dir, image_target_dir, format)
+  def handle_nonasciidoc_table_cell(cell, mathematical, image_output_dir, image_target_dir, format, inline)
     text = cell.instance_variable_get :@text
-    text, source_modified = handle_inline_stem cell, text, mathematical, image_output_dir, image_target_dir, format
+    text, source_modified = handle_inline_stem cell, text, mathematical, image_output_dir, image_target_dir, format, inline
     if source_modified
       cell.instance_variable_set :@text, text
     end
   end
 
-  def handle_section_title(sect, mathematical, image_output_dir, image_target_dir, format)
+  def handle_section_title(sect, mathematical, image_output_dir, image_target_dir, format, inline)
     text = sect.instance_variable_get :@title
-    text, source_modified = handle_inline_stem sect, text, mathematical, image_output_dir, image_target_dir, format
+    text, source_modified = handle_inline_stem sect, text, mathematical, image_output_dir, image_target_dir, format, inline
     if source_modified
       sect.instance_variable_set :@title, text
       sect.remove_instance_variable :@subbed_title
     end
   end
 
-  def handle_inline_stem(node, text, mathematical, image_output_dir, image_target_dir, format)
+  def handle_inline_stem(node, text, mathematical, image_output_dir, image_target_dir, format, inline)
     document = node.document
     to_html = document.basebackend? 'html'
     support_stem_prefix = document.attr? 'stem', 'latexmath'
@@ -134,29 +146,37 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
       eq_data.gsub! '\]', ']'
       subs = m[1].nil_or_empty? ? (to_html ? [:specialcharacters] : []) : (node.resolve_pass_subs m[1])
       eq_data = node.apply_subs eq_data, subs unless subs.empty?
-      img_target, img_width, img_height = make_equ_image eq_data, nil, true, mathematical, image_output_dir, image_target_dir, format
-      %(image:#{img_target}[width=#{img_width},height=#{img_height}])
+      img_target, img_width, img_height = make_equ_image eq_data, nil, true, mathematical, image_output_dir, image_target_dir, format, inline
+      if inline
+        %(pass:[<span class="steminline"> #{img_target} </span>])
+      else
+        %(image:#{img_target}[width=#{img_width},height=#{img_height}])
+      end
     } if (text != nil) && (text.include? ':') && ((support_stem_prefix && (text.include? 'stem:')) || (text.include? 'latexmath:'))
 
     [text, source_modified]
   end
 
-  def make_equ_image(equ_data, equ_id, equ_inline, mathematical, image_output_dir, image_target_dir, format)
+  def make_equ_image(equ_data, equ_id, equ_inline, mathematical, image_output_dir, image_target_dir, format, inline)
     input = equ_inline ? %($#{equ_data}$) : %($$#{equ_data}$$)
-
-    unless equ_id
-      equ_id = %(stem-#{::Digest::MD5.hexdigest input})
-    end
-    image_ext = %(.#{format})
-    img_target = %(#{equ_id}#{image_ext})
-    img_file = ::File.join image_output_dir, img_target
 
     # TODO: Handle exceptions.
     result = mathematical.parse input
-    ::IO.write img_file, result[:data]
+    if inline
+      result[:data]
+    else
+      unless equ_id
+        equ_id = %(stem-#{::Digest::MD5.hexdigest input})
+      end
+      image_ext = %(.#{format})
+      img_target = %(#{equ_id}#{image_ext})
+      img_file = ::File.join image_output_dir, img_target
 
-    img_target = ::File.join image_target_dir, img_target unless image_target_dir == '.'
-    [img_target, result[:width], result[:height]]
+      ::IO.write img_file, result[:data]
+
+      img_target = ::File.join image_target_dir, img_target unless image_target_dir == '.'
+      [img_target, result[:width], result[:height]]
+    end
   end
 
   def image_output_and_target_dir(parent)


### PR DESCRIPTION
Instead of writing them to file and creating an image block.

This is only useful when outputting to HTML, but makes a big difference there because one no longer needs to fetch one image per equation from some webserver.

Browser adoption for inline SVGs is at [96.69%](http://caniuse.com/#search=inline%20svg), support goes as far back as IE9.