### PR TITLE
asciidoctor 2.0.0 support

### DIFF
--- a/asciidoctor-mathematical.gemspec
+++ b/asciidoctor-mathematical.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.add_dependency 'ruby-enum', '~> 0.4'
   s.add_runtime_dependency 'mathematical', '~> 1.5', '>= 1.5.8'
-  s.add_runtime_dependency "asciidoctor", '~> 1.5', '>= 1.5.0'
+  s.add_runtime_dependency "asciidoctor", '~> 2.0', '>= 2.0.0'
 end

--- a/lib/asciidoctor-mathematical/version.rb
+++ b/lib/asciidoctor-mathematical/version.rb
@@ -1,5 +1,5 @@
 module Asciidoctor
   module Mathematical
-    VERSION = "0.2.2"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
I'm trying to build a new version of `docker-asciidoctor` to support asciidoctor 2.0.x and need a `asciidoctor-mathematical` with a dependency to asciidoctor 2.0.x