### PR TITLE
Fixed FrozenError

### DIFF
--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -132,7 +132,7 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
 
     source_modified = false
     # TODO skip passthroughs in the source (e.g., +stem:[x^2]+)
-    text.gsub!(stem_rx) {
+    text = text.gsub(stem_rx) {
       if (m = $~)[0].start_with? '\\'
         next m[0][1..-1]
       end


### PR DESCRIPTION
In some documents, latexmath will appear in text passed to `handle_inline_stem` as a frozen string.

By changing line 135 to include `text = text.gsub(stem_rx)` instead of `text.gsub!(stem_rx)`, this error no longer occurs.