### PR TITLE
Make imagesdir relative to source file not working directory

### DIFF
--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -190,7 +190,8 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
       else
         # When imagesdir attribute is set, every relative path is prefixed with it. So the real target dir shall then be relative to the imagesdir, instead of being relative to document root.
         doc_outdir = parent.attr('outdir') || (document.respond_to?(:options) && document.options[:to_dir])
-        abs_imagesdir = parent.normalize_system_path(parent.attr('imagesdir'), doc_outdir)
+        rel_imagesdir = File::join(parent.attr('docdir'), parent.attr('imagesdir'))
+        abs_imagesdir = parent.normalize_system_path(rel_imagesdir, doc_outdir)
         abs_outdir = parent.normalize_system_path(output_dir, base_dir)
         p1 = ::Pathname.new abs_outdir
         p2 = ::Pathname.new abs_imagesdir

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -181,31 +181,53 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
 
   def image_output_and_target_dir(parent)
     document = parent.document
+    doc_dir = parent.attr('docdir')
+    images_dir = parent.attr('imagesdir')
+    images_out_dir = parent.attr('imagesoutdir')
 
-    output_dir = parent.attr('imagesoutdir')
-    if output_dir
+    # if images_dir
+    #   # Relative images paths in the document are resolved relative to the
+    #   # value of the imagesdir attribute (at the time the converter runs).
+    #   if images_out_dir
+    #     # Find images_out_dir relative to images_dir
+    #   else
+    #     # Absolute path of images_out_dir
+    #   end
+    # else
+    #   # The imagesdir attribute is blank by default, which means relative image paths are
+    #   # resolved relative to the input document.
+    #   if images_out_dir
+    #     # Absolute path of images_out_dir
+    #   else
+    #     # Use doc_dir
+    #   end
+    # end
+
+    images_out_dir = [parent.attr('docdir'), parent.attr]
+    images_out_dir = images_out_dir ? parent.attr('docdir') + images_out_dir : nil
+    if images_out_dir
       base_dir = nil
       if parent.attr('imagesdir').nil_or_empty?
-        target_dir = output_dir
+        target_dir = images_out_dir
       else
         # When imagesdir attribute is set, every relative path is prefixed with it. So the real target dir shall then be relative to the imagesdir, instead of being relative to document root.
         doc_outdir = parent.attr('outdir') || (document.respond_to?(:options) && document.options[:to_dir])
-        rel_imagesdir = File::join(parent.attr('docdir'), parent.attr('imagesdir'))
+        rel_imagesdir = ::File::join(parent.attr('docdir'), parent.attr('imagesdir'))
         abs_imagesdir = parent.normalize_system_path(rel_imagesdir, doc_outdir)
-        abs_outdir = parent.normalize_system_path(output_dir, base_dir)
+        abs_outdir = parent.normalize_system_path(images_out_dir, base_dir)
         p1 = ::Pathname.new abs_outdir
         p2 = ::Pathname.new abs_imagesdir
         target_dir = p1.relative_path_from(p2).to_s
       end
     else
       base_dir = parent.attr('outdir') || (document.respond_to?(:options) && document.options[:to_dir])
-      output_dir = parent.attr('imagesdir')
+      images_out_dir = parent.attr('imagesdir')
       # since we store images directly to imagesdir, target dir shall be NULL and asciidoctor converters will prefix imagesdir.
       target_dir = "."
     end
 
-    output_dir = parent.normalize_system_path(output_dir, base_dir)
-    return [output_dir, target_dir]
+    images_out_dir = parent.normalize_system_path(images_out_dir, base_dir)
+    return [images_out_dir, target_dir]
   end
 
 end


### PR DESCRIPTION
Not sure if `File::join` is the best way, but this fixes an issue where nested documents broke the path to the stem/latexmath images when `imagesdir` is defined.

For example, you have this project file tree: 

basedir/images/cat.png
basedir/subdir/source.adoc 

Assume source.adoc defines attributes as:
```
:imagesdir: ../../images
:imagesoutdir: {imagesdir}/equations/generated_images
```

In a large project, you want to run asciidoctor-pdf from the base directory using a wildcard to find all the files. The `imagesdir` attribute expands to its string `../../images`, which is then interpreted as relative to the working directory from which asciidoctor-pdf was called, rather than the directory of the source file containing the attribute. I've appended `imagesdir` the `docdir` attribute so that it is always interpreted from the point of view that it was declared. 

I've never programmed in Ruby before, so I had trouble referencing the `join_path` method from the `path_resolver.rb` class, but maybe that would be more desirable than `File::join`?