### PR TITLE
Fix relative image paths

### DIFF
--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -197,7 +197,7 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
         target_dir = p1.relative_path_from(p2).to_s
       end
     else
-      base_dir = parent.attr('outdir') || (document.respond_to?(:options) && document.options[:to_dir])
+      base_dir = parent.attr('docdir')
       output_dir = parent.attr('imagesdir')
       # since we store images directly to imagesdir, target dir shall be NULL and asciidoctor converters will prefix imagesdir.
       target_dir = "."

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -180,30 +180,23 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
   end
 
   def image_output_and_target_dir(parent)
-    document = parent.document
-
     output_dir = parent.attr('imagesoutdir')
     if output_dir
-      base_dir = nil
       if parent.attr('imagesdir').nil_or_empty?
         target_dir = output_dir
       else
         # When imagesdir attribute is set, every relative path is prefixed with it. So the real target dir shall then be relative to the imagesdir, instead of being relative to document root.
-        doc_outdir = parent.attr('outdir') || (document.respond_to?(:options) && document.options[:to_dir])
-        abs_imagesdir = parent.normalize_system_path(parent.attr('imagesdir'), doc_outdir)
-        abs_outdir = parent.normalize_system_path(output_dir, base_dir)
-        p1 = ::Pathname.new abs_outdir
-        p2 = ::Pathname.new abs_imagesdir
-        target_dir = p1.relative_path_from(p2).to_s
+        abs_imagesdir = ::Pathname.new parent.normalize_system_path(parent.attr('imagesdir'), parent.attr('docdir'))
+        abs_outdir = ::Pathname.new parent.normalize_system_path(output_dir)
+        target_dir = abs_outdir.relative_path_from(abs_imagesdir).to_s
       end
     else
-      base_dir = parent.attr('docdir')
       output_dir = parent.attr('imagesdir')
       # since we store images directly to imagesdir, target dir shall be NULL and asciidoctor converters will prefix imagesdir.
       target_dir = "."
     end
 
-    output_dir = parent.normalize_system_path(output_dir, base_dir)
+    output_dir = parent.normalize_system_path(output_dir, parent.attr('docdir'))
     return [output_dir, target_dir]
   end
 

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -179,24 +179,24 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
     end
   end
 
-  def image_output_and_target_dir(parent)
-    output_dir = parent.attr('imagesoutdir')
+  def image_output_and_target_dir(doc)
+    output_dir = doc.attr('imagesoutdir')
     if output_dir
-      if parent.attr('imagesdir').nil_or_empty?
+      if doc.attr('imagesdir').nil_or_empty?
         target_dir = output_dir
       else
         # When imagesdir attribute is set, every relative path is prefixed with it. So the real target dir shall then be relative to the imagesdir, instead of being relative to document root.
-        abs_imagesdir = ::Pathname.new parent.normalize_system_path(parent.attr('imagesdir'), parent.attr('docdir'))
-        abs_outdir = ::Pathname.new parent.normalize_system_path(output_dir)
+        abs_imagesdir = ::Pathname.new doc.normalize_system_path(doc.attr('imagesdir'), doc.attr('docdir'))
+        abs_outdir = ::Pathname.new doc.normalize_system_path(output_dir)
         target_dir = abs_outdir.relative_path_from(abs_imagesdir).to_s
       end
     else
-      output_dir = parent.attr('imagesdir')
+      output_dir = doc.attr('imagesdir')
       # since we store images directly to imagesdir, target dir shall be NULL and asciidoctor converters will prefix imagesdir.
       target_dir = "."
     end
 
-    output_dir = parent.normalize_system_path(output_dir, parent.attr('docdir'))
+    output_dir = doc.normalize_system_path(output_dir, doc.attr('docdir'))
     return [output_dir, target_dir]
   end
 

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -186,7 +186,7 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
         target_dir = output_dir
       else
         # When imagesdir attribute is set, every relative path is prefixed with it. So the real target dir shall then be relative to the imagesdir, instead of being relative to document root.
-        abs_imagesdir = ::Pathname.new doc.normalize_system_path(doc.attr('imagesdir'), doc.attr('docdir'))
+        abs_imagesdir = ::Pathname.new doc.normalize_system_path(doc.attr('imagesdir'))
         abs_outdir = ::Pathname.new doc.normalize_system_path(output_dir)
         target_dir = abs_outdir.relative_path_from(abs_imagesdir).to_s
       end


### PR DESCRIPTION
I have a project with a non-flat directory tree, similar to this:

basedir/images/<many images>.png
basedir/content/<many sub-files>.adoc
basedir/docs/master_doc.adoc

Assume source.adoc defines the following attributes:
```
:imagesdir: ../../images
:imagesoutdir: {imagesdir}/equations/generated_images
```

I found that asciidoctor-pdf could not retrieve the asciidoctor-mathematical generated images if `:imagesdir:` was set, if `:imagesoutdir:` was _not_ set, or both not set.

This PR allows any combination of `:imagesdir:` and `:imagesoutdir:` attributes to work even if they are empty or not in a flat directory tree. The attributes can be relative or absolute paths. If the attributes are left empty, the images are created in the same directory as the AsciiDoc source file, which I believe is the default behaviour for asciidoctor-pdf if `:imagesdir:` is not set.