### PR TITLE
Added required libs for Ubuntu build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you experience any compilation errors (caused by Mathematical) try running:
 `brew link gettext --force` (you can unlink the libraries later if you want).
 
 #### Ubuntu
-`sudo apt-get -qq -y install bison flex libffi-dev libxml2-dev libgdk-pixbuf2.0-dev libcairo2-dev libpango1.0-dev fonts-lyx cmake`
+`sudo apt-get -qq -y install bison flex libffi-dev libxml2-dev libgdk-pixbuf2.0-dev libcairo2-dev libpango1.0-dev fonts-lyx cmake libwebp-dev libzstd-dev`
 
 #### Fedora 28
 


### PR DESCRIPTION
I had to install this on Ubuntu 22.04 and spent hours looking for the libs.  I was getting errors below, and installing these libs fixed the issue. 

```
linking shared-object mathematical/mathematical.so
/usr/bin/ld: cannot find -lwebp: No such file or directory
/usr/bin/ld: cannot find -lzstd: No such file or directory
collect2: error: ld returned 1 exit status
make: *** [Makefile:262: mathematical.so] Error 1

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/3.0.0/gems/mathematical-1.6.14 for inspection.
Results logged to /var/lib/gems/3.0.0/extensions/x86_64-linux/3.0.0/mathematical-1.6.14/gem_make.out
```