### PR TITLE
Add initial zoom setting support for stem blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These attributes can be set to tweak behaviors of this package:
 | mathematical-format | format of generated images                                            | svg, png            | png           |
 | mathematical-ppi    | ppi of generated images, only valid for png files                     | any positive number | 300.0         |
 | mathematical-inline | if present will inline equations as svg (only useful for HTML output) | true/false          | false         |
+| mathematical-zoom   | adjust size of the svg formulas in stem blocks                        | any positive number | 1.0           |
 
 ## Usage
 `asciidoctor-pdf -r asciidoctor-mathematical -o test.pdf sample.adoc`

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -25,13 +25,16 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
     end
     # The no-args constructor defaults to SVG and standard delimiters ($..$ for inline, $$..$$ for block)
     mathematical = ::Mathematical.new format: format, ppi: ppi
+    # Use separate Mathematical instace to render formulas in stem blocks to adjust their size
+    zoom = ((document.attr 'mathematical-zoom') || '1.0').to_f
+    mathematical_blocks = ::Mathematical.new format: format, ppi: ppi, zoom: zoom
     unless inline
       image_output_dir, image_target_dir = image_output_and_target_dir document
       ::Asciidoctor::Helpers.mkdir_p image_output_dir unless ::File.directory? image_output_dir
     end
 
     (document.find_by context: :stem, traverse_documents: true).each do |stem|
-      handle_stem_block stem, mathematical, image_output_dir, image_target_dir, format, inline
+      handle_stem_block stem, mathematical_blocks, image_output_dir, image_target_dir, format, inline
     end
 
     document.find_by(traverse_documents: true) {|b|

--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -25,7 +25,7 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
     end
     # The no-args constructor defaults to SVG and standard delimiters ($..$ for inline, $$..$$ for block)
     mathematical = ::Mathematical.new format: format, ppi: ppi
-    # Use separate Mathematical instace to render formulas in stem blocks to adjust their size
+    # Use separate Mathematical instance to render formulas in stem blocks for adjusting their size
     zoom = ((document.attr 'mathematical-zoom') || '1.0').to_f
     mathematical_blocks = ::Mathematical.new format: format, ppi: ppi, zoom: zoom
     unless inline

--- a/lib/asciidoctor-mathematical/version.rb
+++ b/lib/asciidoctor-mathematical/version.rb
@@ -1,5 +1,5 @@
 module Asciidoctor
   module Mathematical
-    VERSION = "0.3.5"
+    VERSION = "0.3.6"
   end
 end


### PR DESCRIPTION
I need to change size of the formulas in STEM blocks in a document. I found that `zoom` setting supported by Mathematical, but not accessible from Asciidoctor. This small patch add `mathematical-zoom` document attribute to adjust formula size in STEM blocks but ignore inline STEM.