### PR TITLE
Make inline svg-references unique

### DIFF
--- a/lib/asciidoctor-mathematical/extension.rb
+++ b/lib/asciidoctor-mathematical/extension.rb
@@ -8,6 +8,7 @@ autoload :Mathematical, 'mathematical'
 class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
   LineFeed = %(\n)
   StemInlineMacroRx = /\\?(stem|(?:latex|ascii)math):([a-z,]*)\[(.*?[^\\])\]/m
+  @@counter = 0
 
   def process document
     return unless document.attr? 'stem'
@@ -156,7 +157,10 @@ class MathematicalTreeprocessor < Asciidoctor::Extensions::Treeprocessor
     # TODO: Handle exceptions.
     result = mathematical.parse input
     if inline
-      result[:data]
+      cnt = @@counter
+      @@counter += 1
+      # All ids created by mathematical.parse are the same, so create some uniqueness
+      result[:data].gsub(/(id="|href="#)glyph/, "\\1glyph-#{cnt}")
     else
       unless equ_id
         equ_id = %(stem-#{::Digest::MD5.hexdigest input})


### PR DESCRIPTION
mathematical.parse always creates the same id, "glyph-0-0".  When inlining in html this results in clashing svgs which are not rendered correctly.

Fix by inserting a counter in the id, resulting in unique ids.

Changes ids from "glyph-0-0" to eg. "glyph-19-0-0".

Test-document test.adoc:

````
:stem:
latexmath:[A] latexmath:[B] latexmath:[C]
````

Run:

In a browser (chrome and firefox tested) this looks like "A A A" before the commit, and "A B C" after.